### PR TITLE
Minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Python based radio frequency satellite tracking
 To view data attached as example:
 
 ```
-python .\rfplot.py  -p data -P 2021-08-04T20_48_35 -s 50 -l 1800 -C 4171
+python3 rfplot.py -p data -P 2021-08-04T20:48:35 -s 50 -l 1800 -C 4171
 ```

--- a/rfplot.py
+++ b/rfplot.py
@@ -22,8 +22,8 @@ if __name__ == "__main__":
     mpl.rcParams['backend'] = "TkAgg"
 
     parser = argparse.ArgumentParser(description='rfplot: plot RF observations', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-p', help='Input path to parent directory /a/b/')
-    parser.add_argument('-P', help='Filename prefix c in c_??????.bin')
+    parser.add_argument('-p', help='Input path to parent directory /a/b/', required=True)
+    parser.add_argument('-P', help='Filename prefix c in c_??????.bin', required=True)
     parser.add_argument('-s', type=int, default=0,  help='Number of starting subintegration')
     parser.add_argument('-l', type=int, default=3600,  help='Number of subintegrations to plot')
     parser.add_argument('-C', type=int,  help='Site ID', default=4171)

--- a/rfplot.py
+++ b/rfplot.py
@@ -16,7 +16,8 @@ from skyfield.api import load, wgs84, utc
 
 from modest import imshow
 
-if __name__ == "__main__":
+
+def main():
     mpl.rcParams['keymap.save'].remove('s')
     mpl.rcParams['keymap.fullscreen'].remove('f')
     mpl.rcParams['backend'] = "TkAgg"
@@ -214,3 +215,7 @@ if __name__ == "__main__":
     fig.canvas.mpl_connect('key_press_event', on_press)
     fig.canvas.mpl_connect('button_press_event', on_click)
     plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
3 minor changes:

- Update the README with the correct prefix name
- Set `-p` and `-P` parameters as mandatory so the user gets a clear error message instead of a stack trace
- Add a proper main(). This is more 'pythonic' and is needed later to make a clean wheel package, that could even be uploaded to pypi.


On another branch i already experimented with packaging a wheel: https://github.com/MartinHerren/pystrf/tree/package
and even tried a little package on test.pypi: https://test.pypi.org/project/pystrf-package-test/ than can be installed with `pip install --extra-index-url https://test.pypi.org/simple pystrf-package-test` (in a virtualenv or system wide) and then the new rfplot command is available.
There is still some reflexions about the source layout/structure (the directories...) to be done to make packaging clean. This will also help to add tests later.